### PR TITLE
feat: Send submission updates to real time updates queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Below is a diagram of the overall architecture of the system with the Submission
 
 ## Documentation
 
-Please, refer to the following documents for more information about the tests micro-service:
+Please, refer to the following documents for more information about the Submissions Status Updater micro-service:
 
-| Document                               | Description                                                                 |
-| -------------------------------------- | --------------------------------------------------------------------------- |
-| [Contributing](./docs/contributing.md) | Contributing guidelines.                                                    |
-| [Environment](./docs/environment.md)   | A description of the environment variables used by the tests micro-service. |
+| Document                               | Description                                                                                      |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| [Contributing](./docs/contributing.md) | Contributing guidelines.                                                                         |
+| [Environment](./docs/environment.md)   | A description of the environment variables used by the Submissions Status Updater micro-service. |

--- a/src/application/submissions-status-updater-use-cases.go
+++ b/src/application/submissions-status-updater-use-cases.go
@@ -8,7 +8,8 @@ import (
 )
 
 type SubmissionsStatusUpdaterUseCases struct {
-	SubmissionsRepository definitions.SubmissionsRepository
+	SubmissionsRepository           definitions.SubmissionsRepository
+	SubmissionsRealTimeUpdatesQueue definitions.SubmissionsRealTimeUpdatesQueue
 }
 
 func (useCases *SubmissionsStatusUpdaterUseCases) UpdateSubmissionStatus(dto *dtos.SubmissionStatusUpdateDTO) error {
@@ -19,6 +20,12 @@ func (useCases *SubmissionsStatusUpdaterUseCases) UpdateSubmissionStatus(dto *dt
 		return err
 	}
 
-	// TODO: Send submission status update to the submissions real time updates queue
+	// Send submission status update to the submissions real time updates queue
+	err = useCases.SubmissionsRealTimeUpdatesQueue.EnqueueUpdate(dto)
+	if err != nil {
+		log.Println("[SubmissionsStatusUpdaterUseCases] Error enqueuing submission status update: " + err.Error())
+		return err
+	}
+
 	return nil
 }

--- a/src/domain/definitions/submissions-real-time-updates-queue.go
+++ b/src/domain/definitions/submissions-real-time-updates-queue.go
@@ -1,0 +1,8 @@
+package definitions
+
+import "github.com/upb-code-labs/submissions-status-updater-microservice/src/domain/dtos"
+
+type SubmissionsRealTimeUpdatesQueue interface {
+	// Publishes a message to the queue
+	EnqueueUpdate(updateDTO *dtos.SubmissionStatusUpdateDTO) error
+}

--- a/src/infrastructure/implementations/rubmissions-real-time-updates-queue-implementation.go
+++ b/src/infrastructure/implementations/rubmissions-real-time-updates-queue-implementation.go
@@ -1,0 +1,127 @@
+package implementations
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/upb-code-labs/submissions-status-updater-microservice/src/config/connections"
+	"github.com/upb-code-labs/submissions-status-updater-microservice/src/domain/dtos"
+)
+
+type SubmissionsRealTimeUpdatesQueueMgr struct {
+	Queue *amqp.Queue
+}
+
+// ## Singleton instance ##
+
+// submissionsRealTimeUpdatesQueueMgr Singleton instance
+var submissionsRealTimeUpdatesQueueMgr *SubmissionsRealTimeUpdatesQueueMgr
+
+// GetSubmissionsRealTimeUpdatesQueueMgrInstance returns the singleton instance of the submissionsRealTimeUpdatesQueueMgr
+func GetSubmissionsRealTimeUpdatesQueueMgrInstance() *SubmissionsRealTimeUpdatesQueueMgr {
+	if submissionsRealTimeUpdatesQueueMgr == nil {
+		submissionsRealTimeUpdatesQueueMgr = &SubmissionsRealTimeUpdatesQueueMgr{
+			Queue: getSubmissionsRealTimeUpdatesQueue(),
+		}
+	}
+
+	return submissionsRealTimeUpdatesQueueMgr
+}
+
+// getSubmissionsRealTimeUpdatesQueue returns a pointer to the queue
+func getSubmissionsRealTimeUpdatesQueue() *amqp.Queue {
+	noQueueHasBeenDeclared :=
+		submissionsRealTimeUpdatesQueueMgr == nil ||
+			submissionsRealTimeUpdatesQueueMgr.Queue == nil
+
+	if noQueueHasBeenDeclared {
+		ch := connections.GetRabbitMQChannel()
+
+		// Declare queue
+		qName := "submission-real-time-updates"
+		qDurable := true
+		qAutoDelete := false
+		qExclusive := false
+		qNoWait := false
+		qArgs := amqp.Table{}
+
+		q, err := ch.QueueDeclare(
+			qName,
+			qDurable,
+			qAutoDelete,
+			qExclusive,
+			qNoWait,
+			qArgs,
+		)
+
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		// Set fair dispatch
+		maxPrefetchCount := 4 // Limit to 4 updates per worker
+		err = ch.Qos(
+			maxPrefetchCount,
+			0,
+			false,
+		)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		log.Println("[RabbitMQ]: Submission real time updates queue declared")
+		return &q
+	}
+
+	return submissionsRealTimeUpdatesQueueMgr.Queue
+}
+
+// ## Methods implementation ##
+// EnqueueUpdate enqueues a submission status update
+func (queueMgr *SubmissionsRealTimeUpdatesQueueMgr) EnqueueUpdate(updateDTO *dtos.SubmissionStatusUpdateDTO) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	ch := connections.GetRabbitMQChannel()
+
+	// Parse update to JSON
+	json, err := json.Marshal(updateDTO)
+	if err != nil {
+		log.Println(
+			"[RabbitMQ Submissions Real Time Updates]: Error parsing submission status update to JSON",
+			err.Error(),
+		)
+		return err
+	}
+
+	// Publish
+	mshExchange := ""
+	mshRoutingKey := queueMgr.Queue.Name
+	mshMandatory := false
+	mshImmediate := false
+
+	err = ch.PublishWithContext(
+		ctx,
+		mshExchange,
+		mshRoutingKey,
+		mshMandatory,
+		mshImmediate,
+		amqp.Publishing{
+			ContentType: "application/json",
+			Body:        json,
+		},
+	)
+
+	if err != nil {
+		log.Println(
+			"[RabbitMQ Submissions Real Time Updates]: Error publishing submission status update",
+			err.Error(),
+		)
+		return err
+	}
+
+	return nil
+}

--- a/src/infrastructure/submission-status-updates-queue.go
+++ b/src/infrastructure/submission-status-updates-queue.go
@@ -57,7 +57,10 @@ func getRabbitMQSubmissionsStatusUpdatesQueue() *amqp.Queue {
 	)
 
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(
+			"[RabbitMQ]: Error declaring submissions status updates queue: ",
+			err.Error(),
+		)
 	}
 
 	// Set fair dispatch
@@ -69,7 +72,10 @@ func getRabbitMQSubmissionsStatusUpdatesQueue() *amqp.Queue {
 	)
 
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(
+			"[RabbitMQ]: Error setting fair dispatch for submissions status updates queue: ",
+			err.Error(),
+		)
 	}
 
 	// Set queue
@@ -101,7 +107,10 @@ func (queueMgr *SubmissionStatusUpdatesQueueMgr) ListenForSubmissionStatusUpdate
 		qArgs,
 	)
 	if err != nil {
-		log.Fatal(err.Error())
+		log.Fatal(
+			"[RabbitMQ Submissions Status Updates Queue]: Error consuming queue: ",
+			err.Error(),
+		)
 	}
 
 	// Set channel
@@ -113,7 +122,9 @@ func (queueMgr *SubmissionStatusUpdatesQueueMgr) ListenForSubmissionStatusUpdate
 
 // processSubmissionStatusUpdates creates an infinite loop that processes submission status updates
 func (queueMgr *SubmissionStatusUpdatesQueueMgr) processSubmissionStatusUpdates() {
-	log.Println("[RabbitMQ]: Listening for submission status updates")
+	log.Println(
+		"[RabbitMQ Submissions Status Updates Queue]: Listening for submission status updates...",
+	)
 
 	// Process each message in a separate goroutine
 	for msg := range queueMgr.Channel {
@@ -129,17 +140,26 @@ func (queueMgr *SubmissionStatusUpdatesQueueMgr) processSubmissionStatusUpdate(m
 	dto := &dtos.SubmissionStatusUpdateDTO{}
 	err := json.Unmarshal(msg.Body, dto)
 	if err != nil {
-		log.Println("[RabbitMQ]: Error unmarshalling message: " + err.Error())
+		log.Println(
+			"[RabbitMQ Submissions Status Updates Queue]: Error parsing submission status update: ",
+			err.Error(),
+		)
 		return
 	}
 
 	// Log message to console
-	log.Println("[RabbitMQ]: Received submission status update", dto.SubmissionUUID)
+	log.Println(
+		"[RabbitMQ]: Received submission status update",
+		dto.SubmissionUUID,
+	)
 
 	// Update submission status
 	err = queueMgr.UseCases.UpdateSubmissionStatus(dto)
 	if err != nil {
-		log.Println("[RabbitMQ]: Error updating submission status: " + err.Error())
+		log.Println(
+			"[RabbitMQ Submissions Status Updates Queue]: Error updating submission status: ",
+			err.Error(),
+		)
 		return
 	}
 }

--- a/src/infrastructure/submission-status-updates-queue.go
+++ b/src/infrastructure/submission-status-updates-queue.go
@@ -26,7 +26,8 @@ func GetSubmissionStatusUpdatesQueueMgr() *SubmissionStatusUpdatesQueueMgr {
 		submissionStatusUpdatesQueueMgrInstance = &SubmissionStatusUpdatesQueueMgr{
 			Queue: getRabbitMQSubmissionsStatusUpdatesQueue(),
 			UseCases: &application.SubmissionsStatusUpdaterUseCases{
-				SubmissionsRepository: implementations.GetSubmissionsPgRepository(),
+				SubmissionsRepository:           implementations.GetSubmissionsPgRepository(),
+				SubmissionsRealTimeUpdatesQueue: implementations.GetSubmissionsRealTimeUpdatesQueueMgrInstance(),
 			},
 			// Channel is set when listening for submission status updates
 		}
@@ -156,10 +157,6 @@ func (queueMgr *SubmissionStatusUpdatesQueueMgr) processSubmissionStatusUpdate(m
 	// Update submission status
 	err = queueMgr.UseCases.UpdateSubmissionStatus(dto)
 	if err != nil {
-		log.Println(
-			"[RabbitMQ Submissions Status Updates Queue]: Error updating submission status: ",
-			err.Error(),
-		)
 		return
 	}
 }


### PR DESCRIPTION
## Includes 📋

- Update `README` to replace mentions to the `tests-runner` micro-service
- Instantiate `submission-real-time-updates` queue
- Send message to the new queue after updating the entry in the database

## Related Issues 🔎

Closes #3 

<!-- 
## Notes 📝

Additional notes or implementation details. -->