### PR TITLE
ci: Update infrastructure repository on new release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,6 @@ jobs:
       contents: read
       packages: write
     needs:
-      - version
       - release
     steps:
       - uses: actions/checkout@v3
@@ -75,3 +74,20 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ needs.version.outputs.version }}
+
+  update-infrastructure:
+    runs-on: ubuntu-22.04
+    needs:
+      - docker
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: infrastructure
+          github_token: ${{ secrets.INFRASTRUCTURE_WORKFLOW_TRIGGER_PAT }}
+          workflow_file_name: bump-service.yaml
+          client_payload: |
+            {
+              "service": "submissions_status_updater_microservice",
+              "version": "${{ needs.version.outputs.version }}"
+            }


### PR DESCRIPTION
## Includes 📋

- Update version of the service's image in the infrastructure repository when a new release is created. 

<!-- 
## Related Issues 🔎

What issues does this PR fix or reference? You may use "Closes #<issue number>" to automatically close the issue when this PR is merged. -->

<!-- 
## Notes 📝

Additional notes or implementation details. -->